### PR TITLE
Verify that stored uuid isn't an empty string

### DIFF
--- a/src/ios/CDVUniqueDeviceID.m
+++ b/src/ios/CDVUniqueDeviceID.m
@@ -18,6 +18,14 @@
         
         NSString *uuid = [UICKeyChainStore stringForKey:@"uuid"];
 
+        if ([uuid length] == 0) {
+            uuid = nil;
+        }
+
+        if ([uuidUserDefaults length] == 0) {
+            uuidUserDefaults = nil;
+        }
+
         if ( uuid && !uuidUserDefaults) {
             [defaults setObject:uuid forKey:@"uuid"];
             [defaults synchronize];


### PR DESCRIPTION
While testing my app, I got into a weird, confusing state where I had an empty uuid stored in my keychain. This should prevent anyone else from suffering that terrible fate.

Possibly related to Paldom/UniqueDeviceID#15?
